### PR TITLE
Bugfix: AppManifest.json as part of release assets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: check-json

--- a/src/python/app/workflows/build-docker-image.yml
+++ b/src/python/app/workflows/build-docker-image.yml
@@ -168,6 +168,6 @@ jobs:
         if: ${{ steps.image_build.outcome == 'success' }}
         uses: actions/upload-artifact@v3
         with:
-          name: "AppManifest.json"
+          name: AppManifest
           path: ./app/AppManifest.json
           if-no-files-found: error

--- a/src/python/app/workflows/release.yml
+++ b/src/python/app/workflows/release.yml
@@ -102,13 +102,13 @@ jobs:
         with:
           workflow: ci.yml
           workflow_conclusion: success
-
-      - name: ${{ matrix.component.Name }} -- Upload AppManifest.json to artifacts"
-        uses: actions/upload-artifact@v3
+          path: ./ci-artifacts
+      
+      - name: ${{ matrix.component.Name }} -- Upload assets
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: "AppManifest.json"
-          path: ./AppManifest.json
-          if-no-files-found: error
+          files: ./ci-artifacts/AppManifest/AppManifest.json
 
   release-documentation:
     name: Generate release documentation

--- a/src/python/app/workflows/release.yml
+++ b/src/python/app/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           workflow: ci.yml
           workflow_conclusion: success
           path: ./ci-artifacts
-      
+
       - name: ${{ matrix.component.Name }} -- Upload assets
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
This PR implements upload of AppManifest.json as an asset in Release workflow.