### PR TITLE
Add proper tagging strategy for license checker

### DIFF
--- a/src/common/workflows/check-licenses.yml
+++ b/src/common/workflows/check-licenses.yml
@@ -29,6 +29,8 @@ on:
 jobs:
   check-licenses:
     runs-on: ubuntu-latest
+    env:
+      LICENSE_CHECKER_TAG_SPECIFIER: v1.2
     name: Check Software Licenses
 
     steps:
@@ -39,8 +41,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: eclipse-velocitas/license-check
-          ref: v1.2.3
           path: .github/actions/license-check
+
+      - name: Checkout desired license-check tag specifier
+        run: |
+          cd .github/actions/license-check
+          git fetch --all --tags
+          LATEST_TAG_BY_SPECIFIER=$(git tag --list --sort=-version:refname "$LICENSE_CHECKER_TAG_SPECIFIER*" | head -n 1)
+          git checkout --progress --force refs/tags/$LATEST_TAG_BY_SPECIFIER
 
       - name: Run License Checker
         uses: ./.github/actions/license-check


### PR DESCRIPTION
This PR adds a strategy to get always the latest tag by the version tag specifier:

v1 -> v1.2.3
v1.1 -> v1.1.0
v1.2 -> v1.2.3