### PR TITLE
change action to avoid permissions

### DIFF
--- a/src/app/workflows/build-docker-image.yml
+++ b/src/app/workflows/build-docker-image.yml
@@ -158,13 +158,14 @@ jobs:
             results/Documentation/renderer/*
 
       - name: "${{ matrix.component.name }} -- Publish Trivy Scan Results"
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: mikepenz/action-junit-report@v3
         if: ${{ always() && steps.image_build.outcome == 'success' }}
         with:
           check_name: Trivy Scan Results (${{ matrix.component.name }})
-          comment_title: Trivy Scan Results (${{ matrix.component.name }})
-          fail_on: "errors"
-          junit_files: ./junit.xml
+          report_paths: ./junit.xml
+          summary: true
+          update_check: true
+          annotate_only: true
 
       - name: "${{ matrix.component.name }} -- Upload image to artifacts"
         if: ${{ steps.image_build.outcome == 'success' }}

--- a/src/python-app/workflows/ci.yml
+++ b/src/python-app/workflows/ci.yml
@@ -73,11 +73,14 @@ jobs:
           coverage2clover -i results/CodeCoverage/cobertura-coverage.xml -o results/CodeCoverage/clover.xml
           coveragepy-lcov --data_file_path ./.coverage --output_file_path results/CodeCoverage/lcov.info
 
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
         if: always()
         with:
-          junit_files: ./results/UnitTest/junit.xml
+          report_paths: ./results/UnitTest/junit.xml
+          summary: true
+          update_check: true
+          annotate_only: true
 
       #########################################################
       # This step was disabled temporarily due to the required
@@ -223,11 +226,14 @@ jobs:
           pip install -r app/tests/requirements.txt
           pytest ./app/tests/integration --override-ini junit_family=xunit1 --junit-xml=./results/IntTest/junit.xml
 
-      - name: Publish integration test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
         if: always()
         with:
-          junit_files: ./results/IntTest/junit.xml
+          report_paths: ./results/IntTest/junit.xml
+          summary: true
+          update_check: true
+          annotate_only: true
 
       - name: Clone release documentation action repository
         uses: actions/checkout@v3


### PR DESCRIPTION
In order to avoid write permissions for the workflows, we have to use another action. With this action we do not add comments to the PR anymore, but add a summary to the workflow directly. An example can be seen here: https://github.com/eclipse-velocitas/vehicle-app-python-template/actions/runs/5077879265