### PR TITLE
disable provenance

### DIFF
--- a/src/app/workflows/build-docker-image.yml
+++ b/src/app/workflows/build-docker-image.yml
@@ -101,6 +101,7 @@ jobs:
         id: image_build
         uses: docker/build-push-action@v4
         with:
+          provenance: false
           pull: true
           push: false
           outputs: |


### PR DESCRIPTION
The latest releases of the action used to build images enable provenance generation by default (https://github.com/docker/build-push-action/releases). Unfortunately the version of skopeo which is available on Ubuntu (https://packages.ubuntu.com/jammy/skopeo) can't handle this (https://github.com/containers/skopeo/issues/1874). Because of this issue the release workflow currently fails for multiarch images.

Workflow failing: https://github.com/SoftwareDefinedVehicle/fix-release/actions/runs/5886792105/job/15965199767

Workflow success: https://github.com/SoftwareDefinedVehicle/fix-release/actions/runs/5886945148/job/15965594968

Since we don't need provenance for now, we can simply disable it and the release works again.