### PR TITLE
fix: get right runtime version also when package name in velocitas.json is an URI

### DIFF
--- a/src/app/scripts/deploy_image_from_artifact.sh
+++ b/src/app/scripts/deploy_image_from_artifact.sh
@@ -20,7 +20,7 @@ APP_ARTIFACT_NAME=$(cat $ROOT_DIRECTORY/${{ appManifestPath }} | jq -r .name | t
 APP_NAME_LOWERCASE=$(echo $APP_ARTIFACT_NAME | tr '[:upper:]' '[:lower:]')
 APP_PORT=50008
 APP_REGISTRY="k3d-registry.localhost:12345"
-RUNTIME_VERSION=$(cat $ROOT_DIRECTORY/.velocitas.json | jq -r '.packages[]| select(.name=="devenv-runtimes")'.version)
+RUNTIME_VERSION=$(cat $ROOT_DIRECTORY/.velocitas.json | jq -r '.packages[]| select(.name | contains("devenv-runtimes"))'.version)
 HELM_CONFIG_DIR="$HOME/.velocitas/packages/devenv-runtimes/$RUNTIME_VERSION/runtime_k3d/src/app_deployment/config/helm"
 
 local_tag="$APP_REGISTRY/$APP_NAME_LOWERCASE:local"


### PR DESCRIPTION
When creating a vehicle application repos from the new vehicle-app-template the packages inside .velocitas json are configures as an URI and not plain "devenv-...".

This PR changes how to receive the correct runtime version for the deploy from artifact script