### PR TITLE
Give job write permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           git config --global --add safe.directory $( pwd )
 
       - name: Identify changes in devenv repo
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: changesInPath
         with:
           filters: |

--- a/src/cpp-app/workflows/release.yml
+++ b/src/cpp-app/workflows/release.yml
@@ -18,6 +18,11 @@ on:
   release:
     types: [published, edited]
 
+# Needed if GITHUB_TOKEN by default do not have right to create release
+permissions:
+  contents: write
+  packages: write
+
 jobs:
 
   get-app-name:
@@ -76,7 +81,12 @@ jobs:
         with:
           checkName: Merge Trivy results
           token: ${{ secrets.GITHUB_TOKEN }}
-          timeoutSeconds: 1800
+          # This workflow does not trigger a build, instead it relies on that a successful build
+          # exists for this commit. If triggering this workflow just after a new commit has been
+          # uploaded we will need to wait for the "Merge Trivy results" to finish
+          # Building the default C++ App on Github may take long time, 70 minutes observed
+          # Setting limit to 100 minutes to have some margin
+          timeoutSeconds: 6000
           intervalSeconds: 20
 
       - name: Download builds from Build multiarch image workflow artifacts
@@ -145,7 +155,7 @@ jobs:
           path: generated_md
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: "0.89.4"
           extended: true
@@ -222,7 +232,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to GH Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{github.workspace}}/hugo/public

--- a/src/python-app/workflows/release.yml
+++ b/src/python-app/workflows/release.yml
@@ -18,6 +18,11 @@ on:
   release:
     types: [published, edited]
 
+# Needed if GITHUB_TOKEN by default do not have right to create release
+permissions:
+  contents: write
+  packages: write
+
 jobs:
 
   get-app-name:
@@ -162,7 +167,7 @@ jobs:
           templatePath: ./.github/actions/templates
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: "0.89.4"
           extended: true
@@ -242,7 +247,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to GH Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{github.workspace}}/hugo/public


### PR DESCRIPTION
Necessary step to fix/merge:

- https://github.com/eclipse-velocitas/vehicle-app-python-template/pull/246
- https://github.com/eclipse-velocitas/vehicle-app-python-template/issues/240
- https://github.com/eclipse-velocitas/vehicle-app-python-template/issues/242
- https://github.com/eclipse-velocitas/vehicle-app-cpp-template/issues/101

In short:

- When you create a fork by using the templates the GITHUB_TOKEN seems to by default only give read access
- That means the release workflow does not run successfully
- Fixed by adding write rights
- Also increased timeout as building C++ is slow!
- There does not seem to be a needed to do a similar change in https://github.com/eclipse-velocitas/devenv-github-workflows/blob/main/src/python-sdk/workflows/release.yaml Maybe we inherit read/write capabilities there.

If/When merged, the ambition is to create a v6.0.3 release to be able to update the template repos in similar way
