### PR TITLE
Update license check, version and pre-commit

### DIFF
--- a/src/app/workflows/gen-desired-state.yml
+++ b/src/app/workflows/gen-desired-state.yml
@@ -42,10 +42,11 @@ jobs:
           velocitas init -v
 
       - name: Extract version from tag
+        id: get_version
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo Version: $VERSION
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version-without-v=$VERSION" >> $GITHUB_OUTPUT
 
       - id: github-repository-name-case-adjusted
         name: Prepare repository name in lower case for docker upload.
@@ -56,7 +57,7 @@ jobs:
       - name: "Generate desired state for ${{ inputs.app_name }}"
         working-directory: ${{github.workspace}}
         env:
-          VAPP_VERSION: ${{ env.VERSION }}
+          VAPP_VERSION: ${{ steps.get_version.outputs.version-without-v }}
           REGISTRY: "ghcr.io/${{steps.github-repository-name-case-adjusted.outputs.lowercase}}"
         run: |
           velocitas exec pantaris-integration generate-desired-state -s $(echo $REGISTRY/${{ inputs.app_name }}:$VAPP_VERSION | tr '[:upper:]' '[:lower:]')

--- a/src/app/workflows/gen-desired-state.yml
+++ b/src/app/workflows/gen-desired-state.yml
@@ -41,8 +41,11 @@ jobs:
           sudo chmod +x /usr/bin/velocitas
           velocitas init -v
 
-      - id: get_version
-        uses: battila7/get-version-action@v2
+      - name: Extract version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo Version: $VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - id: github-repository-name-case-adjusted
         name: Prepare repository name in lower case for docker upload.
@@ -53,7 +56,7 @@ jobs:
       - name: "Generate desired state for ${{ inputs.app_name }}"
         working-directory: ${{github.workspace}}
         env:
-          VAPP_VERSION: ${{ steps.get_version.outputs.version-without-v }}
+          VAPP_VERSION: ${{ env.VERSION }}
           REGISTRY: "ghcr.io/${{steps.github-repository-name-case-adjusted.outputs.lowercase}}"
         run: |
           velocitas exec pantaris-integration generate-desired-state -s $(echo $REGISTRY/${{ inputs.app_name }}:$VAPP_VERSION | tr '[:upper:]' '[:lower:]')

--- a/src/common/workflows/check-licenses.yml
+++ b/src/common/workflows/check-licenses.yml
@@ -25,6 +25,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   check-licenses:
@@ -58,10 +61,12 @@ jobs:
 
       - name: Run dash
         shell: bash
-        continue-on-error: true
         run: |
           wget -O dash.jar "https://repo.eclipse.org/content/repositories/dash-licenses/org/eclipse/dash/org.eclipse.dash.licenses/1.0.2/org.eclipse.dash.licenses-1.0.2.jar"
-          java -jar dash.jar clearlydefined.input -summary DEPENDENCIES
+          java -jar dash.jar clearlydefined.input -summary DEPENDENCIES > dash.out 2>&1 || true
+          echo -e "Dash output: \n\`\`\` " >> $GITHUB_STEP_SUMMARY
+          cat dash.out >> $GITHUB_STEP_SUMMARY
+          echo -e "\n\`\`\`"
 
       - name: Upload dash input/output as artifacts
         uses: actions/upload-artifact@v4
@@ -71,3 +76,4 @@ jobs:
           path: |
             clearlydefined.input
             DEPENDENCIES
+            dash.out

--- a/src/common/workflows/check-licenses.yml
+++ b/src/common/workflows/check-licenses.yml
@@ -25,9 +25,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 jobs:
   check-licenses:

--- a/src/cpp-app/workflows/ci.yml
+++ b/src/cpp-app/workflows/ci.yml
@@ -93,4 +93,4 @@ jobs:
           cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
 
       - name: Run Linters
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1

--- a/src/cpp-app/workflows/release.yml
+++ b/src/cpp-app/workflows/release.yml
@@ -59,12 +59,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Extract version from tag
+        id: get_version
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo Version: $VERSION
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version-without-v=$VERSION" >> $GITHUB_OUTPUT
 
-      - run: echo "Using VehicleApp version ${{ env.VERSION }} from tag"
+      - run: echo "Using VehicleApp version ${{ steps.get_version.outputs.version-without-v }} from tag"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -106,7 +107,7 @@ jobs:
         env:
           VAPP_IMAGE: ${{ env.APP_NAME }}-multiarch-oci-archive/${{ env.APP_NAME }}-oci-multiarch.tar
           VAPP_NAME: ${{ env.APP_NAME }}
-          VAPP_VERSION: ${{ env.VERSION }}
+          VAPP_VERSION: ${{ steps.get_version.outputs.version-without-v }}
           REGISTRY: "ghcr.io/${{steps.github-repository-name-case-adjusted.outputs.lowercase}}"
         run: |
           tag=$(echo docker://$REGISTRY/$VAPP_NAME:$VAPP_VERSION | tr '[:upper:]' '[:lower:]')

--- a/src/cpp-app/workflows/release.yml
+++ b/src/cpp-app/workflows/release.yml
@@ -58,10 +58,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - id: get_version
-        uses: battila7/get-version-action@v2
+      - name: Extract version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo Version: $VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-      - run: echo "Using VehicleApp version ${{ steps.get_version.outputs.version-without-v }} from tag"
+      - run: echo "Using VehicleApp version ${{ env.VERSION }} from tag"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -103,7 +106,7 @@ jobs:
         env:
           VAPP_IMAGE: ${{ env.APP_NAME }}-multiarch-oci-archive/${{ env.APP_NAME }}-oci-multiarch.tar
           VAPP_NAME: ${{ env.APP_NAME }}
-          VAPP_VERSION: ${{ steps.get_version.outputs.version-without-v }}
+          VAPP_VERSION: ${{ env.VERSION }}
           REGISTRY: "ghcr.io/${{steps.github-repository-name-case-adjusted.outputs.lowercase}}"
         run: |
           tag=$(echo docker://$REGISTRY/$VAPP_NAME:$VAPP_VERSION | tr '[:upper:]' '[:lower:]')

--- a/src/cpp-sdk/workflows/ci.yml
+++ b/src/cpp-sdk/workflows/ci.yml
@@ -107,4 +107,4 @@ jobs:
       #    path: code-coverage-results.md
 
       - name: Run Linters
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1

--- a/src/python-app/workflows/ci.yml
+++ b/src/python-app/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           git config --global --add safe.directory $( pwd )
 
       - name: Run Linters
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
       - name: Clone Release Documentation Action repository
         uses: actions/checkout@v4

--- a/src/python-app/workflows/release.yml
+++ b/src/python-app/workflows/release.yml
@@ -58,10 +58,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - id: get_version
-        uses: battila7/get-version-action@v2
+      - name: Extract version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo Version: $VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-      - run: echo "Using VehicleApp version ${{ steps.get_version.outputs.version-without-v }} from tag"
+      - run: echo "Using VehicleApp version ${{ env.VERSION }} from tag"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -98,7 +101,7 @@ jobs:
         env:
           VAPP_IMAGE: ${{ env.APP_NAME }}-multiarch-oci-archive/${{ env.APP_NAME }}-oci-multiarch.tar
           VAPP_NAME: ${{ env.APP_NAME }}
-          VAPP_VERSION: ${{ steps.get_version.outputs.version-without-v }}
+          VAPP_VERSION: ${{ env.VERSION }} 
           REGISTRY: "ghcr.io/${{steps.github-repository-name-case-adjusted.outputs.lowercase}}"
         run: |
           tag=$(echo docker://$REGISTRY/$VAPP_NAME:$VAPP_VERSION | tr '[:upper:]' '[:lower:]')

--- a/src/python-app/workflows/release.yml
+++ b/src/python-app/workflows/release.yml
@@ -59,12 +59,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Extract version from tag
+        id: get_version
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo Version: $VERSION
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version-without-v=$VERSION" >> $GITHUB_OUTPUT
 
-      - run: echo "Using VehicleApp version ${{ env.VERSION }} from tag"
+      - run: echo "Using VehicleApp version ${{ steps.get_version.outputs.version-without-v }}  from tag"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -101,7 +102,7 @@ jobs:
         env:
           VAPP_IMAGE: ${{ env.APP_NAME }}-multiarch-oci-archive/${{ env.APP_NAME }}-oci-multiarch.tar
           VAPP_NAME: ${{ env.APP_NAME }}
-          VAPP_VERSION: ${{ env.VERSION }} 
+          VAPP_VERSION: ${{ steps.get_version.outputs.version-without-v }}
           REGISTRY: "ghcr.io/${{steps.github-repository-name-case-adjusted.outputs.lowercase}}"
         run: |
           tag=$(echo docker://$REGISTRY/$VAPP_NAME:$VAPP_VERSION | tr '[:upper:]' '[:lower:]')

--- a/src/python-sdk/workflows/ci.yaml
+++ b/src/python-sdk/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
           python3 -m pip install tox-gh-actions
 
       - name: Run Linters
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
       - name: Run the databroker binary
         run: |


### PR DESCRIPTION
Previously both gave warnings.

- Pre-commit as using Node.js 16
- License check as error code was presented

Fixes #58 
Fixes #57

Changes tested (for python app) on this repo https://github.com/erikbosch/vehicle-example-app2

**Example pre-commit**

- Previous build: https://github.com/erikbosch/vehicle-example-app2/actions/runs/9464628807
- New build: https://github.com/erikbosch/vehicle-example-app2/actions/runs/9513024768

Warning only present in old build
```
Run unit tests and linters
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

**Example License check**

- Old run: https://github.com/erikbosch/vehicle-example-app2/actions/runs/9464326913
- New run: https://github.com/erikbosch/vehicle-example-app2/actions/runs/9513024770

Old run gave warning. In new run dash output is presented.

Old:

```
Check Software Licenses
Process completed with exit code 23.
```

New:

```
[main] INFO Querying Eclipse Foundation for license data for 79 items.
[main] INFO Found 23 items.
[main] INFO Querying ClearlyDefined for license data for 57 items.
[main] INFO Found 57 items.
[main] INFO License information could not be automatically verified for the following content:
[main] INFO 
[main] INFO git/github/actions/download-artifact/v4
[main] INFO git/github/actions/setup-java/v4
[main] INFO git/github/actions/setup-node/v4
[main] INFO git/github/actions/setup-python/v5
[main] INFO git/github/actions/upload-artifact/v4
[main] INFO git/github/aquasecurity/trivy-action/0.19.0
[main] INFO git/github/dawidd6/action-download-artifact/v3
[main] INFO git/github/docker/build-push-action/v5
[main] INFO git/github/docker/setup-buildx-action/v3
[main] INFO git/github/docker/setup-qemu-action/v3
[main] INFO git/github/fountainhead/action-wait-for-check/v1.2.0
[main] INFO git/github/mikepenz/action-junit-report/v4
[main] INFO git/github/softprops/action-gh-release/v2
[main] INFO pypi/pypi/-/coverage/7.3.2
[main] INFO pypi/pypi/-/exceptiongroup/1.1.3
[main] INFO pypi/pypi/-/grpcio/1.59.0
[main] INFO pypi/pypi/-/mypy/1.5.1
[main] INFO pypi/pypi/-/paho-mqtt/1.6.1
[main] INFO pypi/pypi/-/parameterized/0.9.0
[main] INFO pypi/pypi/-/setuptools/58.1.0
[main] INFO pypi/pypi/-/typing-extensions/4.11.0
[main] INFO pypi/pypi/-/velocitas-sdk/0.14.1
[main] INFO pypi/pypi/-/wheel/0.41.2
[main] INFO 
[main] INFO This content is either not correctly mapped by the system, or requires review.
```

Changes inspired by what exist in https://github.com/eclipse-kuksa/kuksa-actions/tree/main/check-dash. If a token is available then one could consider supporting automatic review requests as well.

**Example Battila7**

Previously we got warnings like:

![image](https://github.com/eclipse-velocitas/devenv-github-workflows/assets/30996601/c40ec942-8dc0-4db8-ad10-85ed3e34041f)

Updated code tested with tags of type `v0.0.4`, `0.0.5` and `tarzan`. See results at https://github.com/erikbosch/vehicle-example-app2/pkgs/container/vehicle-example-app2%2Fsampleapp




