### PR TITLE
Add cron to ensure-lifecyle and check-license

### DIFF
--- a/src/common/workflows/check-licenses.yml
+++ b/src/common/workflows/check-licenses.yml
@@ -25,6 +25,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 4 * * *"
 
 jobs:
   check-licenses:

--- a/src/common/workflows/ensure-lifecycle.yml
+++ b/src/common/workflows/ensure-lifecycle.yml
@@ -22,6 +22,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 4 * * *"
 
 jobs:
   check-sync:


### PR DESCRIPTION
Projects/Repos may not always specify dependencies that are constant over time. As an example, devcontainer-base-images v0.3 is not constant over time as it may be patched.
By using a cron job it is possible to detect if there are any changes that must be reflected in the repository, for example by updating workflows or NOTICE file.

Cron interval identical to interval in
https://github.com/eclipse-velocitas/vehicle-app-cpp-template/blob/main/.github/workflows/check-devcontainer.yml

The idea for this PR came from a  recent observation where builds started to fail for "main". It was detected first when a totally unrelated PR was created as we do not check main regularly.

https://github.com/eclipse-velocitas/vehicle-app-cpp-template/actions/runs/9683189970
https://github.com/eclipse-velocitas/vehicle-app-cpp-template/actions/runs/9682919291
