### PR TITLE
Add printout on lifecycle mismatch

### DIFF
--- a/src/common/workflows/ensure-lifecycle.yml
+++ b/src/common/workflows/ensure-lifecycle.yml
@@ -52,6 +52,15 @@ jobs:
             echo "changed=0" >> $GITHUB_OUTPUT
           else
             echo "changed=1" >> $GITHUB_OUTPUT
+
+            echo -e "## Summary of detected changes\n" >> $GITHUB_STEP_SUMMARY
+            echo -e "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            git status --porcelain >> $GITHUB_STEP_SUMMARY
+            echo -e "\`\`\`" >>  $GITHUB_STEP_SUMMARY
+            echo -e "## Diff Details\n" >> $GITHUB_STEP_SUMMARY
+            echo -e "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            git diff >> $GITHUB_STEP_SUMMARY
+            echo -e "\`\`\`" >>  $GITHUB_STEP_SUMMARY
           fi
         shell: bash
 


### PR DESCRIPTION
Today if "ensure lifecycle" fails you do not get much information. This PR introduces a printout highlighting the actual changes., which could be helpful in identifying which changes that should be copied to this repository.

Example run:

https://github.com/SoftwareDefinedVehicle/vehicle-app-python-template/actions/runs/10214130424

![image](https://github.com/user-attachments/assets/0bdb1188-62c7-4c91-bd48-ab24bfa1cc2f)
