### PR TITLE
Fix for Python venv usage in velocitas exec

### DIFF
--- a/src/app/workflows/check-devcontainer.yml
+++ b/src/app/workflows/check-devcontainer.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           runCmd: |
             pip3 install -r .devcontainer/tests/automated_tests/requirements.txt
+            export PATH=$HOME/.local/bin:$PATH
             pytest -sx .devcontainer/tests
 
       - name: Upload logs


### PR DESCRIPTION
Fix required for `velocitas exec` of Python scripts in venv because the pytest package is not found